### PR TITLE
Add Makefile for generating .bc files in tests/saw/test-files

### DIFF
--- a/tests/saw/test-files/Makefile
+++ b/tests/saw/test-files/Makefile
@@ -1,0 +1,7 @@
+C_FILES  := $(wildcard *.c)
+BC_FILES := $(C_FILES:.c=.bc)
+
+all: $(BC_FILES)
+
+%.bc: %.c
+	clang -g -c -emit-llvm -o $@ $<


### PR DESCRIPTION
I can never quite remember the right `clang` incantation needed to create these `.bc` files, so this `Makefile` does that for you.